### PR TITLE
Update staticvec from 0.9 to 0.10

### DIFF
--- a/cl-traits/Cargo.toml
+++ b/cl-traits/Cargo.toml
@@ -3,7 +3,7 @@ arrayvec = { default-features = false, optional = true, version = "0.5" }
 cl-traits-derive = { optional = true, path = "../cl-traits-derive", version = "1.0" }
 serde = { default-features = false, optional = true, version = "1.0" }
 smallvec = { default-features = false, optional = true, version = "1.2" }
-staticvec = { default-features = false, optional = true, version = "0.9" }
+staticvec = { default-features = false, optional = true, version = "0.10" }
 tinyvec = { default-features = false, optional = true, version = "0.3" }
 
 [features]


### PR DESCRIPTION
0.9 was broken in a way that can't be fixed right now by [this compiler PR,](https://github.com/rust-lang/rust/pull/70107) so I had to remove the impacted functions for now and release a 0.10.0 version of the crate without them. This allows staticvec and anything depending on it to compile with nightlies released after June 3rd.